### PR TITLE
Update mongoose to 5.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thorin-store-mongo",
   "author": "UNLOQ Systems",
-  "version": "1.0.4",
+  "version": "1.1.4",
   "dependencies": {
     "mongoose": "5.10.7"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "UNLOQ Systems",
   "version": "1.0.4",
   "dependencies": {
-    "mongoose": "5.9.7"
+    "mongoose": "5.10.7"
   },
   "description": "Thorin.js MongoDB store",
   "main": "index.js",


### PR DESCRIPTION
Updating mongoose to get rid of the warnings generated by `npm audit`